### PR TITLE
Improve search speed, consistent output

### DIFF
--- a/detections/attack_protection_features_turned_off.yml
+++ b/detections/attack_protection_features_turned_off.yml
@@ -30,13 +30,23 @@ splunk: >
     data.type=sapi data.description IN ("Update Suspicious IP Throttling settings",
     "Update Breached Password Detection settings", "Update Brute-force settings")
     data.details.response.body.enabled=false
+    | fields 'data.description', _time
     | eval event_type = case(
       'data.description'="Update Suspicious IP Throttling settings", "Suspicious IP Throttling has been disabled",
       'data.description'="Update Breached Password Detection settings", "Breached Password Detection has been disabled",
       'data.description'="Update Brute-force settings", "Brute-force has been disabled"
       )
     ```Display the information in a table```
-    | table event_type
+    | stats count by event_type
+    | eval Status="Disabled"
+    | append 
+              [ | makeresults
+                | eval mv_event_type=split("Suspicious IP Throttling has been disabled,Breached Password Detection has been disabled,Brute-force has been disabled", ",")
+                | mvexpand mv_event_type
+                | eval event_type=mv_event_type, Status="Enabled"
+                | fields event_type, Status
+              ]
+    | stats max(Status) as Status by event_type
 comments:
     - The splunk query above shall be tuned to reflect a valid tenant name.
     - Adjust the detection to monitor the attack feature in use.


### PR DESCRIPTION
Speed improvements
- Switch to from table to stats
- Add fields command

Consistent Output
- Always output the 3 options
- Show a status for each

Future improvements could be to output a 4th row to show the search time, for screenshotting for evidence gathering.